### PR TITLE
ReRun getting wrong object

### DIFF
--- a/lib/bamboo_ci/api.rb
+++ b/lib/bamboo_ci/api.rb
@@ -32,7 +32,7 @@ module BambooCi
         url += "&bamboo.variable.github_#{variable[:name]}=#{variable[:value]}"
       end
 
-      @logger.debug "Submission URL:\n  #{url}"
+      logger(Logger::DEBUG, "Submission URL:\n  #{url}")
 
       # Fetch Request
       post_request(URI(url))
@@ -50,7 +50,7 @@ module BambooCi
     def add_comment_to_ci(key, comment)
       url = "https://127.0.0.1/rest/api/latest/result/#{key}/comment"
 
-      @logger.debug "Comment Submission URL:\n  #{url}"
+      logger(Logger::DEBUG, "Comment Submission URL:\n  #{url}")
 
       # Fetch Request
       post_request(URI(url), body: "<comment><content>#{comment}</content></comment>")
@@ -70,7 +70,7 @@ module BambooCi
 
       JSON.parse(http.request(req).body)
     rescue StandardError => e
-      @logger.error "HTTP GET Request failed (#{e.message}) for #{uri.host}"
+      logger(Logger::ERROR, "HTTP GET Request failed (#{e.message}) for #{uri.host}")
 
       nil
     end
@@ -86,7 +86,7 @@ module BambooCi
 
       # Fetch Request
       resp = http.request(req)
-      @logger.debug(resp)
+      logger(Logger::DEBUG, resp)
 
       resp
     end
@@ -105,11 +105,11 @@ module BambooCi
 
       # Fetch Request
       resp = http.request(req)
-      @logger.debug("#{resp.code} - #{resp.body.inspect}")
+      logger(Logger::DEBUG, "#{resp.code} - #{resp.body.inspect}")
 
       resp
     rescue StandardError => e
-      @logger.error "HTTP POST Request failed (#{e.message}) for #{uri.host}"
+      logger(Logger::ERROR, "HTTP POST Request failed (#{e.message}) for #{uri.host}")
 
       nil
     end
@@ -133,11 +133,11 @@ module BambooCi
 
       # Fetch Request
       resp = http.request(req)
-      @logger.debug(resp)
+      logger(Logger::DEBUG, resp)
 
       resp
     rescue StandardError => e
-      @logger.error "HTTP POST Request failed (#{e.message}) for #{uri.host}"
+      logger(Logger::ERROR, "HTTP POST Request failed (#{e.message}) for #{uri.host}")
 
       nil
     end
@@ -153,6 +153,14 @@ module BambooCi
     def fetch_user_pass
       netrc = Netrc.read
       netrc['ci1.netdef.org']
+    end
+
+    def logger(severity, message)
+      return if @logger_manager.nil?
+
+      @logger_manager.each do |logger_object|
+        logger_object.add(severity, message)
+      end
     end
   end
 end

--- a/lib/bamboo_ci/plan_run.rb
+++ b/lib/bamboo_ci/plan_run.rb
@@ -23,10 +23,22 @@ module BambooCi
     attr_accessor :checks_run, :ci_variables
 
     def initialize(check_suite, logger_level: Logger::INFO)
+      @logger_manager = []
+      @logger_level = logger_level
+
+      logger_class = Logger.new('github_plan_run.log', 0, 1_024_000)
+      logger_class.level = logger_level
+
+      logger_app = Logger.new('github_app.log', 1, 1_024_000)
+      logger_app.level = logger_level
+
+      @logger_manager << logger_class
+      @logger_manager << logger_app
+
+      logger(Logger::INFO, "BambooCi::PlanRun - CheckSuite: #{check_suite.inspect}")
+
       @check_suite = check_suite
       @ci_variables = []
-      @logger = Logger.new($stdout)
-      @logger.level = logger_level
     end
 
     def start_plan
@@ -38,10 +50,10 @@ module BambooCi
       when 400..500
         failed(@response)
       when 0
-        @logger.unknown 'HTTP Request error'
+        logger(Logger::UNKNOWN, 'HTTP Request error')
         418
       else
-        @logger.unknown "Unmapped HTTP error (Bamboo): #{@response.code.to_i}\nPR: #{@check_suite.inspect}"
+        logger(Logger::UNKNOWN, "Unmapped HTTP error (Bamboo): #{@response.code.to_i}\nPR: #{@check_suite.inspect}")
         failed(@response)
       end
     end
@@ -57,21 +69,21 @@ module BambooCi
     def success(response)
       hash = JSON.parse(response.body)
 
-      @logger.debug "\nCI Submitted:\n#{hash}"
+      logger(Logger::DEBUG, "\nCI Submitted:\n#{hash}")
 
       @ci_key = hash['buildResultKey']
 
       response = generate_comment
 
-      @logger.debug "Comment Submit response: #{response.inspect}"
+      logger(Logger::DEBUG, "Comment Submit response: #{response.inspect}")
 
       200
     end
 
     def failed(response)
-      @logger.debug ''
-      @logger.debug "ci submission failed: #{response.body}"
-      @logger.debug "Error #{response.code}"
+      logger(Logger::DEBUG, '')
+      logger(Logger::DEBUG, "ci submission failed: #{response.body}")
+      logger(Logger::DEBUG, "Error #{response.code}")
 
       return 429 if response.body.include?('reached the maximum number of concurrent builds')
 
@@ -86,9 +98,15 @@ module BambooCi
       comment += "Merge Git Commit ID #{@check_suite.commit_sha_ref}"
       comment += " on top of base Git Commit ID #{@check_suite.base_sha_ref}"
 
-      @logger.debug comment
+      logger(Logger::DEBUG, comment)
 
       add_comment_to_ci(@ci_key, comment)
+    end
+
+    def logger(severity, message)
+      @logger_manager.each do |logger_object|
+        logger_object.add(severity, message)
+      end
     end
   end
 end

--- a/lib/bamboo_ci/plan_run.rb
+++ b/lib/bamboo_ci/plan_run.rb
@@ -91,9 +91,10 @@ module BambooCi
     end
 
     def generate_comment
-      comment = "GitHub Merge Request #{@check_suite.pull_request.github_pr_id}\n"
+      url = "https://github.com/#{@check_suite.pull_request.repository}/pull/#{@check_suite.pull_request.github_pr_id}"
+      comment = "GitHub Merge Request #{@check_suite.pull_request.github_pr_id} (#{url})\n"
       comment += "for GitHub Repo #{@check_suite.pull_request.repository}, " \
-                 "branch #{@check_suite.work_branch}\n\n"
+                 "branch #{@check_suite.merge_branch}\n\n"
       comment += "Request to merge from #{@check_suite.pull_request.repository}\n"
       comment += "Merge Git Commit ID #{@check_suite.commit_sha_ref}"
       comment += " on top of base Git Commit ID #{@check_suite.base_sha_ref}"

--- a/lib/github/build_plan.rb
+++ b/lib/github/build_plan.rb
@@ -153,7 +153,11 @@ module Github
         next unless ci_job.persisted?
 
         ci_job.create_check_run
-        ci_job.in_progress(@github_check) if ci_job.checkout_code?
+
+        next unless ci_job.checkout_code?
+
+        url = "https://ci1.netdef.org/browse/#{ci_job.job_ref}"
+        ci_job.in_progress(@github_check, { title: ci_job.name, summary: "Details at [#{url}](#{url})" })
       end
     end
 

--- a/lib/github/re_run.rb
+++ b/lib/github/re_run.rb
@@ -261,7 +261,7 @@ module Github
         next unless ci_job.checkout_code?
 
         url = "https://ci1.netdef.org/browse/#{ci_job.job_ref}"
-        ci_job.in_progress(@github_check, output: { title: ci_job.name, summary: "Details at [#{url}](#{url})" })
+        ci_job.in_progress(@github_check, { title: ci_job.name, summary: "Details at [#{url}](#{url})" })
       end
     end
 

--- a/spec/lib/bamboo_ci/api_spec.rb
+++ b/spec/lib/bamboo_ci/api_spec.rb
@@ -12,7 +12,7 @@ class Dummy
   include BambooCi::Api
 
   def initialize
-    @logger = Logger.new('/dev/null')
+    @logger_manager = [Logger.new('/dev/null')]
   end
 end
 

--- a/spec/lib/bamboo_ci/plan_run_spec.rb
+++ b/spec/lib/bamboo_ci/plan_run_spec.rb
@@ -37,11 +37,14 @@ describe BambooCi::PlanRun do
     let(:check_suite) { create(:check_suite) }
     let(:status) { 200 }
     let(:body) { '{"buildResultKey": 1}' }
+    let(:url) do
+      "https://github.com/#{check_suite.pull_request.repository}/pull/#{check_suite.pull_request.github_pr_id}"
+    end
 
     let(:comment) do
-      "<comment><content>GitHub Merge Request #{check_suite.pull_request.github_pr_id}\n" \
+      "<comment><content>GitHub Merge Request #{check_suite.pull_request.github_pr_id} (#{url})\n" \
         "for GitHub Repo #{check_suite.pull_request.repository}, " \
-        "branch #{check_suite.work_branch}\n\n" \
+        "branch #{check_suite.merge_branch}\n\n" \
         "Request to merge from #{check_suite.pull_request.repository}\n" \
         "Merge Git Commit ID #{check_suite.commit_sha_ref} " \
         "on top of base Git Commit ID #{check_suite.base_sha_ref}</content></comment>"

--- a/spec/lib/github/re_run_spec.rb
+++ b/spec/lib/github/re_run_spec.rb
@@ -125,6 +125,82 @@ describe Github::ReRun do
       end
     end
 
+    context 'when has two opened PRs' do
+      let(:first_pr) { create(:pull_request, github_pr_id: 12, id: 11, repository: 'test') }
+      let(:second_pr) { create(:pull_request, github_pr_id: 13, id: 12, repository: 'test') }
+      let(:check_suite) { create(:check_suite, :with_running_ci_jobs, pull_request: first_pr) }
+      let(:ci_jobs) { [{ name: 'First Test', job_ref: 'UNIT-TEST-FIRST-1' }] }
+      let(:check_suite_rerun) { CheckSuite.find_by(commit_sha_ref: check_suite.commit_sha_ref, re_run: true) }
+      let(:another_check_suite) { create(:check_suite, :with_running_ci_jobs, pull_request: second_pr) }
+
+      let(:payload) do
+        {
+          'action' => 'created',
+          'comment' => {
+            'body' => 'CI:rerun potato',
+            'user' => { 'login' => 'John' }
+          },
+          'repository' => { 'full_name' => check_suite.pull_request.repository },
+          'issue' => { 'number' => check_suite.pull_request.github_pr_id }
+        }
+      end
+
+      let(:pull_request_info) do
+        {
+          head: {
+            ref: 'master'
+          },
+          base: {
+            ref: 'test',
+            sha: check_suite.base_sha_ref
+          }
+        }
+      end
+
+      let(:pull_request_commits) do
+        [
+          { sha: check_suite.commit_sha_ref, date: Time.now }
+        ]
+      end
+
+      before do
+        allow(Octokit::Client).to receive(:new).and_return(fake_client)
+        allow(fake_client).to receive(:find_app_installations).and_return([{ 'id' => 1 }])
+        allow(fake_client).to receive(:create_app_installation_access_token).and_return({ 'token' => 1 })
+        allow(fake_client).to receive(:pull_request_commits).and_return(pull_request_commits, [])
+
+        allow(Github::Check).to receive(:new).and_return(fake_github_check)
+        allow(fake_github_check).to receive(:create).and_return(check_suite)
+        allow(fake_github_check).to receive(:add_comment)
+        allow(fake_github_check).to receive(:cancelled)
+        allow(fake_github_check).to receive(:pull_request_info).and_return(pull_request_info)
+
+        allow(BambooCi::PlanRun).to receive(:new).and_return(fake_plan_run)
+        allow(fake_plan_run).to receive(:start_plan).and_return(200)
+        allow(fake_plan_run).to receive(:bamboo_reference).and_return('UNIT-TEST-1')
+
+        allow(BambooCi::StopPlan).to receive(:stop)
+        allow(BambooCi::RunningPlan).to receive(:fetch).with(fake_plan_run.bamboo_reference).and_return(ci_jobs)
+
+        another_check_suite
+      end
+
+      it 'must returns success' do
+        expect(rerun.start).to eq([201, 'Starting re-run'])
+        expect(check_suite_rerun).not_to be_nil
+      end
+
+      it 'must have 2 CheckSuites in first PR' do
+        rerun.start
+        expect(first_pr.check_suites.size).to eq(2)
+      end
+
+      it 'must have 1 CheckSuites in second PR' do
+        rerun.start
+        expect(second_pr.check_suites.size).to eq(1)
+      end
+    end
+
     context 'when you receive an comment' do
       let(:check_suite) { create(:check_suite, :with_running_ci_jobs) }
       let(:ci_jobs) { [{ name: 'First Test', job_ref: 'UNIT-TEST-FIRST-1' }] }


### PR DESCRIPTION
Due to an error in the query we used to search for the pull request during ReRun, this search returned a wrong entry when CI tried to search for the SHA in the branch it did not exist.