### PR TITLE
Watch Dog

### DIFF
--- a/lib/github/check.rb
+++ b/lib/github/check.rb
@@ -61,36 +61,36 @@ module Github
       )
     end
 
-    def queued(id)
-      basic_status(id, 'queued', {})
+    def queued(check_ref, output = {})
+      basic_status(check_ref, 'queued', output)
     end
 
-    def in_progress(id, output = {})
-      basic_status(id, 'in_progress', output)
+    def in_progress(check_ref, output = {})
+      basic_status(check_ref, 'in_progress', output)
     end
 
-    def cancelled(id)
-      completed(id, 'completed', 'cancelled', {})
+    def cancelled(check_ref, output = {})
+      completed(check_ref, 'completed', 'cancelled', output)
     rescue Octokit::NotFound
-      @logger.error "ID ##{id} not found at GitHub"
+      @logger.error "check_ref ##{check_ref} not found at GitHub"
     end
 
-    def success(name, output = {})
-      completed(name, 'completed', 'success', output)
+    def success(check_ref, output = {})
+      completed(check_ref, 'completed', 'success', output)
     rescue Octokit::NotFound
-      @logger.error "ID ##{id} not found at GitHub"
+      @logger.error "check_ref ##{check_ref} not found at GitHub"
     end
 
-    def failure(name, output = {})
-      completed(name, 'completed', 'failure', output)
+    def failure(check_ref, output = {})
+      completed(check_ref, 'completed', 'failure', output)
     rescue Octokit::NotFound
-      @logger.error "ID ##{id} not found at GitHub"
+      @logger.error "check_ref #{check_ref} not found at GitHub"
     end
 
-    def skipped(name)
-      completed(name, 'completed', 'skipped', {})
+    def skipped(check_ref, output = {})
+      completed(check_ref, 'completed', 'skipped', output)
     rescue Octokit::NotFound
-      @logger.error "ID ##{id} not found at GitHub"
+      @logger.error "check_ref ##{check_ref} not found at GitHub"
     end
 
     def installation_id

--- a/lib/github/re_run/base.rb
+++ b/lib/github/re_run/base.rb
@@ -69,11 +69,12 @@ module Github
           logger(Logger::DEBUG, ">>> CI Job: #{ci_job.inspect}")
           next unless ci_job.persisted?
 
-          ci_job.enqueue(@github_check)
+          url = "https://ci1.netdef.org/browse/#{ci_job.job_ref}"
+
+          ci_job.enqueue(@github_check, { title: ci_job.name, summary: "Details at [#{url}](#{url})" })
 
           next unless ci_job.checkout_code?
 
-          url = "https://ci1.netdef.org/browse/#{ci_job.job_ref}"
           ci_job.in_progress(@github_check, { title: ci_job.name, summary: "Details at [#{url}](#{url})" })
         end
       end

--- a/lib/models/ci_job.rb
+++ b/lib/models/ci_job.rb
@@ -33,8 +33,9 @@ class CiJob < ActiveRecord::Base
     update(status: :queued)
   end
 
-  def enqueue(github)
+  def enqueue(github, output = {})
     check_run = github.create(name)
+    github.queued(check_run.id, output)
     update(check_ref: check_run.id, status: :queued)
   end
 

--- a/lib/models/ci_job.rb
+++ b/lib/models/ci_job.rb
@@ -25,6 +25,10 @@ class CiJob < ActiveRecord::Base
     name.downcase.match? 'checkout'
   end
 
+  def finished?
+    !%w[queued in_progress].include?(status.to_s)
+  end
+
   def create_check_run
     update(status: :queued)
   end
@@ -41,8 +45,8 @@ class CiJob < ActiveRecord::Base
     update(check_ref: check_run.id, status: :in_progress)
   end
 
-  def cancelled(github)
-    github.cancelled(check_ref)
+  def cancelled(github, output = {})
+    github.cancelled(check_ref, output)
 
     update(status: :cancelled)
   end
@@ -59,8 +63,8 @@ class CiJob < ActiveRecord::Base
     update(status: :success)
   end
 
-  def skipped(github)
-    github.skipped(check_ref)
+  def skipped(github, output = {})
+    github.skipped(check_ref, output)
 
     update(status: :skipped)
   end

--- a/spec/lib/github/re_run/command_spec.rb
+++ b/spec/lib/github/re_run/command_spec.rb
@@ -60,6 +60,7 @@ describe Github::ReRun::Command do
         allow(fake_github_check).to receive(:add_comment)
         allow(fake_github_check).to receive(:cancelled)
         allow(fake_github_check).to receive(:in_progress)
+        allow(fake_github_check).to receive(:queued)
         allow(fake_github_check).to receive(:comment_reaction_thumb_up)
 
         allow(BambooCi::PlanRun).to receive(:new).and_return(fake_plan_run)

--- a/spec/lib/github/re_run/comment_spec.rb
+++ b/spec/lib/github/re_run/comment_spec.rb
@@ -64,6 +64,7 @@ describe Github::ReRun::Comment do
         allow(fake_github_check).to receive(:add_comment)
         allow(fake_github_check).to receive(:cancelled)
         allow(fake_github_check).to receive(:in_progress)
+        allow(fake_github_check).to receive(:queued)
         allow(fake_github_check).to receive(:comment_reaction_thumb_up)
 
         allow(BambooCi::PlanRun).to receive(:new).and_return(fake_plan_run)
@@ -173,6 +174,7 @@ describe Github::ReRun::Comment do
         allow(fake_github_check).to receive(:create).and_return(check_suite)
         allow(fake_github_check).to receive(:add_comment)
         allow(fake_github_check).to receive(:cancelled)
+        allow(fake_github_check).to receive(:queued)
         allow(fake_github_check).to receive(:pull_request_info).and_return(pull_request_info)
 
         allow(BambooCi::PlanRun).to receive(:new).and_return(fake_plan_run)
@@ -246,6 +248,7 @@ describe Github::ReRun::Comment do
         allow(fake_github_check).to receive(:create).and_return(check_suite)
         allow(fake_github_check).to receive(:add_comment)
         allow(fake_github_check).to receive(:cancelled)
+        allow(fake_github_check).to receive(:queued)
         allow(fake_github_check).to receive(:pull_request_info).and_return(pull_request_info)
 
         allow(BambooCi::PlanRun).to receive(:new).and_return(fake_plan_run)
@@ -277,6 +280,7 @@ describe Github::ReRun::Comment do
       allow(fake_github_check).to receive(:create).and_return(fake_check_suite)
       allow(fake_github_check).to receive(:add_comment)
       allow(fake_github_check).to receive(:cancelled)
+      allow(fake_github_check).to receive(:queued)
       allow(fake_github_check).to receive(:pull_request_info).and_return(pull_request_info)
 
       allow(BambooCi::PlanRun).to receive(:new).and_return(fake_plan_run)

--- a/spec/lib/github/retry_spec.rb
+++ b/spec/lib/github/retry_spec.rb
@@ -61,6 +61,7 @@ describe Github::Retry do
 
         allow(Github::Check).to receive(:new).and_return(fake_github_check)
         allow(fake_github_check).to receive(:create).and_return(ci_job.check_suite)
+        allow(fake_github_check).to receive(:queued)
 
         allow(BambooCi::StopPlan).to receive(:stop)
         allow(BambooCi::Retry).to receive(:restart)

--- a/workers/watch_dog.rb
+++ b/workers/watch_dog.rb
@@ -8,17 +8,87 @@
 #
 #  frozen_string_literal: true
 
-require_relative '../config/sidekiq'
+require 'logger'
 require_relative '../database_loader'
+require_relative '../lib/bamboo_ci/api'
+require_relative '../lib/github/check'
+require_relative '../lib/helpers/configuration'
 
 class WatchDog
-  include Sidekiq::Worker
+  ONE_HOUR = 1 * 60 * 60
 
-  sidekiq_options queue: :default, retry: 1
+  include BambooCi::Api
 
   def perform
-    CheckSuite.joins(:ci_jobs).where(ci_jobs: { status: %w[queued in_progress] }).each do |check_suite|
-      puts check_suite.inspect
+    @logger = Logger.new('watch_dog.log', 0, 1_024_000)
+    check_suites.each do |check_suite|
+      @logger.info ">>> CheckSuite: #{check_suite.inspect}"
+
+      fetch_ci_execution(check_suite)
+
+      @logger.info ">>> Status: #{@result['state']}"
+
+      next if @result['status-code'] == 404
+      next if @result['state'] == 'Unknown'
+
+      check_stages(check_suite)
+    end
+  end
+
+  private
+
+  def check_suites
+    CheckSuite.where(id: check_suites_fetch_map)
+  end
+
+  def check_suites_fetch_map
+    CheckSuite
+      .joins(:ci_jobs)
+      .where(ci_jobs: { status: %w[queued in_progress] }, created_at: [..Time.now - ONE_HOUR])
+      .map(&:id)
+      .uniq
+  end
+
+  def fetch_ci_execution(check_suite)
+    @result = get_status(check_suite.bamboo_ci_ref)
+  end
+
+  def check_stages(check_suite)
+    github_check = Github::Check.new(check_suite)
+    @result.dig('stages', 'stage').each do |stage|
+      stage.dig('results', 'result').each do |result|
+        bamboo_ci_ref = result['buildResultKey']
+
+        ci_job = CiJob.find_by(job_ref: bamboo_ci_ref, check_suite_id: check_suite.id)
+
+        @logger.info ">>> CiJob: #{ci_job.inspect} - Finished? #{ci_job.finished?}"
+        next if ci_job.finished?
+
+        update_ci_job_status(github_check, ci_job, result['state'])
+      end
+    end
+  end
+
+  def update_ci_job_status(github_check, ci_job, state)
+    url = "https://ci1.netdef.org/browse/#{ci_job.job_ref}"
+    output = {
+      title: ci_job.name,
+      summary: "Details at [#{url}](#{url})\nUnfortunately we were unable to access the execution results."
+    }
+
+    @logger.info ">>> CiJob: #{ci_job.inspect} updating status"
+    case state
+    when 'Unknown'
+      ci_job.cancelled(github_check, output)
+    when 'Failed'
+      ci_job.failure(github_check, output)
+    when 'Successful'
+      ci_job.success(github_check, output)
+    else
+      puts 'Ignored'
     end
   end
 end
+
+watch_dog = WatchDog.new
+watch_dog.perform


### PR DESCRIPTION
Allows us to update run statuses when BambooCI crashes or hangs.
Added the CI link to the queued jobs