### PR TITLE
Watch Dog

### DIFF
--- a/db/migrate/20231002182445_add_sync_bamboo.rb
+++ b/db/migrate/20231002182445_add_sync_bamboo.rb
@@ -1,0 +1,15 @@
+#  SPDX-License-Identifier: BSD-2-Clause
+#
+#  20230727101236_add_ci_job_retry.rb
+#  Part of NetDEF CI System
+#
+#  Copyright (c) 2023 by
+#  Network Device Education Foundation, Inc. ("NetDEF")
+#
+#  frozen_string_literal: true
+
+class AddSyncBamboo < ActiveRecord::Migration[6.0]
+  def change
+    add_column :check_suites, :sync, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_27_101236) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_02_182445) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,6 +27,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_27_101236) do
     t.bigint "pull_request_id"
     t.boolean "re_run", default: false
     t.integer "retry", default: 0
+    t.boolean "sync", default: false
     t.index ["pull_request_id"], name: "index_check_suites_on_pull_request_id"
   end
 

--- a/doc/general/console.md
+++ b/doc/general/console.md
@@ -1,0 +1,46 @@
+# Introduction
+
+This document explains how to access the console (IRB) and perform some basic routines.
+
+# Usage
+
+Access the project root and run the following command:
+
+`bin/console.rb <env>`
+
+By default, the production environment is accessed.
+
+Example: `bin/console.rb`
+
+If you want to access the development environment, just run the command: `bin/console.rb development`
+
+# Query
+
+After accessing the terminal, you will have access to all database models and can perform queries 
+using ActiveRecord terminologies.
+
+Example:
+
+It will search for the PullRequest object with ID 2 on GitHub example: https://github.com/opensourcerouting/frr-ci-test/pull/2
+`pr = PullRequest.find_by(github_pr_id: 2)`
+
+The line below can fetch all check_suites for the PR.
+`pr.check_suites`
+
+We are looking for the latest test suite for this PR
+`check_suite = pr.check_suites.last`
+
+The next command allows you to list the jobs that were executed in the suite
+`check_suite.ci_jobs`
+
+The .where command allows you to refine the query to search for a certain value in the case we are looking 
+for a test with the name "TopoTests Debian 10 amd64 Part 1"
+`check_suite.ci_jobs.where(job_ref: 'TopoTests Debian 10 amd64 Part 1')`
+
+# Require
+
+In this version there is still no autoloading of the project's classes, if you wanted to load a class just 
+execute the following command:
+`require_relative 'lib/github/check.rb'`
+
+This will load the Github::Check class which allows you to send information to GitHub

--- a/workers/base.rb
+++ b/workers/base.rb
@@ -1,0 +1,31 @@
+#  SPDX-License-Identifier: BSD-2-Clause
+#
+#  base.rb
+#  Part of NetDEF CI System
+#
+#  Copyright (c) 2023 by
+#  Network Device Education Foundation, Inc. ("NetDEF")
+#
+#  frozen_string_literal: true
+
+require 'logger'
+require_relative '../database_loader'
+require_relative '../lib/bamboo_ci/api'
+require_relative '../lib/github/check'
+require_relative '../lib/helpers/configuration'
+
+class Base
+  include BambooCi::Api
+
+  def fetch_ci_execution(check_suite)
+    @result = get_status(check_suite.bamboo_ci_ref)
+  end
+
+  def check_stages(&block)
+    @result.dig('stages', 'stage').each do |stage|
+      stage.dig('results', 'result').each do |result|
+        yield result if block_given?
+      end
+    end
+  end
+end

--- a/workers/base.rb
+++ b/workers/base.rb
@@ -21,10 +21,10 @@ class Base
     @result = get_status(check_suite.bamboo_ci_ref)
   end
 
-  def check_stages(&block)
+  def check_stages
     @result.dig('stages', 'stage').each do |stage|
       stage.dig('results', 'result').each do |result|
-        yield result if block_given?
+        yield result if block
       end
     end
   end

--- a/workers/single_sync.rb
+++ b/workers/single_sync.rb
@@ -23,9 +23,15 @@ class SingleSync < Base
       return
     end
 
-    github_check = Github::Check.new(check_suite)
-
     fetch_ci_execution(check_suite)
+
+    stages(check_suite)
+  end
+
+  private
+
+  def stages(check_suite)
+    github_check = Github::Check.new(check_suite)
 
     check_stages do |result|
       bamboo_ci_ref = result['buildResultKey']
@@ -41,8 +47,6 @@ class SingleSync < Base
       update_ci_job_status(github_check, ci_job, result['state'])
     end
   end
-
-  private
 
   def create_ci_job(check_suite, result, bamboo_ci_ref, github_check)
     ci_job = CiJob.create(check_suite: check_suite, name: result.dig('plan', 'shortName'), job_ref: bamboo_ci_ref)

--- a/workers/single_sync.rb
+++ b/workers/single_sync.rb
@@ -1,0 +1,76 @@
+#  SPDX-License-Identifier: BSD-2-Clause
+#
+#  final_sync.rb
+#  Part of NetDEF CI System
+#
+#  Copyright (c) 2023 by
+#  Network Device Education Foundation, Inc. ("NetDEF")
+#
+#  frozen_string_literal: true
+
+require 'logger'
+require_relative 'base'
+class SingleSync < Base
+  def perform(bamboo_ci)
+    puts bamboo_ci
+    check_suite = CheckSuite.find_by(bamboo_ci_ref: bamboo_ci)
+
+    puts check_suite.inspect
+
+    if check_suite.nil?
+      puts 'Please inform the CI that you would like to sync like the example: TESTING-GITHUBCHECKBETA-82'
+
+      return
+    end
+
+    github_check = Github::Check.new(check_suite)
+
+    fetch_ci_execution(check_suite)
+
+    check_stages do |result|
+      bamboo_ci_ref = result['buildResultKey']
+
+      ci_job = CiJob.find_by(job_ref: bamboo_ci_ref, check_suite_id: check_suite.id)
+
+      puts "CiJob: #{ci_job.inspect}"
+
+      next if ci_job.finished?
+
+      next create_ci_job(check_suite, result, bamboo_ci_ref, github_check) if ci_job.nil?
+
+      update_ci_job_status(github_check, ci_job, result['state'])
+    end
+  end
+
+  private
+
+  def create_ci_job(check_suite, result, bamboo_ci_ref, github_check)
+    ci_job = CiJob.create(check_suite: check_suite, name: result.dig('plan', 'shortName'), job_ref: bamboo_ci_ref)
+
+    puts ">>> Creating CiJob #{ci_job.inspect}, status: #{result['state']}"
+
+    update_ci_job_status(github_check, ci_job, result['state'])
+  end
+
+  def update_ci_job_status(github_check, ci_job, state)
+    url = "https://ci1.netdef.org/browse/#{ci_job.job_ref}"
+    output = {
+      title: ci_job.name,
+      summary: "Details at [#{url}](#{url})\nUnfortunately we were unable to access the execution results."
+    }
+
+    case state
+    when 'Unknown'
+      ci_job.cancelled(github_check, output)
+    when 'Failed'
+      ci_job.failure(github_check, output)
+    when 'Successful'
+      ci_job.success(github_check, output)
+    else
+      puts 'Ignored'
+    end
+  end
+end
+
+sync = SingleSync.new
+sync.perform(ARGV[0])

--- a/workers/watch_dog.rb
+++ b/workers/watch_dog.rb
@@ -64,7 +64,7 @@ class WatchDog < Base
         @logger.info ">>> CiJob: #{ci_job.inspect} - Finished? #{ci_job.finished?}"
         next if ci_job.finished? && !ci_job.job_ref.nil?
 
-        ci_job.enqueue(github_check) if ci_job.job_ref.nil? and !(ci_job.cancelled? or ci_job.skipped?)
+        ci_job.enqueue(github_check) if ci_job.job_ref.nil?
 
         update_ci_job_status(github_check, ci_job, result['state'])
       end


### PR DESCRIPTION
If there is a problem updating the Job status through Bamboo, we 
need to execute the enqueue and then update it with the correct status.
Allows you to synchronize a CI run with GitHub.