### PR TITLE
ReRun when still running a job

### DIFF
--- a/app/github_app.rb
+++ b/app/github_app.rb
@@ -97,7 +97,7 @@ class GithubApp < Sinatra::Base
     when 'check_run'
       logger.debug "Check Run #{payload.dig('check_run', 'id')} - #{payload['action']}"
 
-      halt 200, 'OK' unless payload['action'].downcase.match?('rerequested')
+      halt 200, 'OK' unless %w[created rerequested].include? payload['action'].downcase
 
       re_run = Github::Retry.new(payload, logger_level: GithubApp.sinatra_logger_level)
       halt re_run.start

--- a/lib/github/check.rb
+++ b/lib/github/check.rb
@@ -93,6 +93,10 @@ module Github
       @logger.error "check_ref ##{check_ref} not found at GitHub"
     end
 
+    def get_check_run(check_ref)
+      @app.check_run(@check_suite.pull_request.repository, check_ref).to_h
+    end
+
     def installation_id
       list = @authenticate_app.find_app_installations
 

--- a/lib/github/retry.rb
+++ b/lib/github/retry.rb
@@ -67,14 +67,6 @@ module Github
       end
     end
 
-    def can_rerun?(check_suite)
-      failure = check_suite.reload.ci_jobs.where(status: :failure).count
-
-      logger(Logger::INFO, ">> #{failure}")
-
-      !failure.positive?
-    end
-
     def enqueued(job)
       github_check = Github::Check.new(job.check_suite)
       previous_job = github_check.get_check_run(job.check_ref)

--- a/lib/github/retry.rb
+++ b/lib/github/retry.rb
@@ -19,8 +19,7 @@ require_relative 'check'
 module Github
   class Retry
     def initialize(payload, logger_level: Logger::INFO)
-      @logger = Logger.new($stdout)
-      @logger.level = logger_level
+      create_logger(logger_level)
 
       @payload = payload
     end
@@ -31,12 +30,20 @@ module Github
       job = CiJob.find_by_check_ref(@payload.dig('check_run', 'id'))
 
       return [404, 'Job not found'] if job.nil?
-      return [304, 'Already enqueued this execution'] if job.queued? or job.in_progress?
+      return [406, 'Already enqueued this execution'] if job.queued? or job.in_progress?
 
-      @logger.debug "Running Job #{job.inspect}"
+      logger(Logger::DEBUG, "Running Job #{job.inspect}")
 
       check_suite = job.check_suite
 
+      return enqueued(job) if check_suite.in_progress?
+
+      normal_flow(check_suite)
+    end
+
+    private
+
+    def normal_flow(check_suite)
       check_suite.update(retry: check_suite.retry + 1)
 
       create_ci_jobs(check_suite)
@@ -46,16 +53,16 @@ module Github
       [200, 'Retrying failure jobs']
     end
 
-    private
-
     def create_ci_jobs(check_suite)
       github_check = Github::Check.new(check_suite)
 
       check_suite.ci_jobs.where.not(status: :success).each do |ci_job|
+        next if ci_job.checkout_code?
+
         ci_job.enqueue(github_check)
         ci_job.update(retry: ci_job.retry + 1)
 
-        @logger.warn "Stopping Job: #{ci_job.job_ref}"
+        logger(Logger::WARN, "Stopping Job: #{ci_job.job_ref}")
         BambooCi::StopPlan.stop(ci_job.job_ref)
       end
     end
@@ -63,9 +70,47 @@ module Github
     def can_rerun?(check_suite)
       failure = check_suite.reload.ci_jobs.where(status: :failure).count
 
-      @logger.info ">> #{failure}"
+      logger(Logger::INFO, ">> #{failure}")
 
       !failure.positive?
+    end
+
+    def enqueued(job)
+      github_check = Github::Check.new(job.check_suite)
+      previous_job = github_check.get_check_run(job.check_ref)
+
+      reason = 'Cannot rerun because there are still tests running'
+
+      logger(Logger::INFO, "enqueued - #{job.inspect} -> #{previous_job[:output]}. Reason: #{reason}")
+
+      summary = previous_job.dig(:output, :summary).to_s
+      summary = "## :warning:#{reason}:warning:\n\n#{summary}"[0..65_535] unless summary.match? reason
+      output = { title: previous_job.dig(:output, :title).to_s, summary: summary }
+
+      job.enqueue(github_check)
+      job.failure(github_check, output)
+
+      [406, reason]
+    end
+
+    def create_logger(logger_level)
+      @logger_manager = []
+      @logger_level = logger_level
+
+      logger_app = Logger.new('github_app.log', 1, 1_024_000)
+      logger_app.level = logger_level
+
+      logger_class = Logger.new('github_retry.log', 0, 1_024_000)
+      logger_class.level = logger_level
+
+      @logger_manager << logger_app
+      @logger_manager << logger_class
+    end
+
+    def logger(severity, message)
+      @logger_manager.each do |logger_object|
+        logger_object.add(severity, message)
+      end
     end
   end
 end

--- a/lib/models/check_suite.rb
+++ b/lib/models/check_suite.rb
@@ -20,4 +20,8 @@ class CheckSuite < ActiveRecord::Base
   def finished?
     ci_jobs.find_by_status(%i[queued in_progress]).nil?
   end
+
+  def in_progress?
+    !finished?
+  end
 end

--- a/spec/lib/github/retry_spec.rb
+++ b/spec/lib/github/retry_spec.rb
@@ -115,7 +115,6 @@ describe Github::Retry do
         }
       end
 
-
       before do
         allow(Octokit::Client).to receive(:new).and_return(fake_client)
         allow(fake_client).to receive(:find_app_installations).and_return([{ 'id' => 1 }])


### PR DESCRIPTION
It is not allowed to call rerun if there are still tests running. This creates a problem in the CI states.