### PR TITLE
Fetch Bamboo Error

### DIFF
--- a/lib/bamboo_ci/result.rb
+++ b/lib/bamboo_ci/result.rb
@@ -17,7 +17,8 @@ module BambooCi
     extend BambooCi::Api
 
     def self.fetch(job_key)
-      get_request(URI("https://127.0.0.1/rest/api/latest/result/#{job_key}?expand=stages.stage.results"))
+      uri = URI("https://127.0.0.1/rest/api/latest/result/#{job_key}?expand=testResults.failedTests.testResult.errors")
+      get_request(uri)
     end
   end
 end

--- a/lib/bamboo_ci/result.rb
+++ b/lib/bamboo_ci/result.rb
@@ -1,0 +1,23 @@
+#  SPDX-License-Identifier: BSD-2-Clause
+#
+#  stop_plan.rb
+#  Part of NetDEF CI System
+#
+#  Copyright (c) 2023 by
+#  Network Device Education Foundation, Inc. ("NetDEF")
+#
+#  frozen_string_literal: true
+
+require 'logger'
+
+require_relative 'api'
+
+module BambooCi
+  class Result
+    extend BambooCi::Api
+
+    def self.fetch(job_key)
+      get_request(URI("https://127.0.0.1/rest/api/latest/result/#{job_key}?expand=stages.stage.results"))
+    end
+  end
+end

--- a/lib/github/update_status.rb
+++ b/lib/github/update_status.rb
@@ -11,6 +11,7 @@
 require 'logger'
 
 require_relative '../../database_loader'
+require_relative '../../lib/bamboo_ci/result'
 
 module Github
   class UpdateStatus
@@ -61,9 +62,43 @@ module Github
       when 'success'
         @job.success(@github_check, @output)
       else
-        @job.failure(@github_check, @output)
-        failures_stats if @job.name.downcase.match? 'topotest' and @failures.is_a? Array
+        failure
       end
+    end
+
+    def failure
+      unable2find = "There was some test that failed, but I couldn't find the log."
+      fetch_and_update_failures(unable2find) if !@output.empty? and @output[:summary].match?(unable2find)
+
+      @job.failure(@github_check, @output)
+      failures_stats if @job.name.downcase.match? 'topotest' and @failures.is_a? Array
+    end
+
+    def fetch_and_update_failures(to_be_replaced)
+      output = BambooCi::Result.fetch(@job.job_ref)
+      return if output.nil? or output.empty?
+
+      @output[:summary] = @output[:summary].sub(to_be_replaced, fetch_failures(output))[0..65_535]
+    end
+
+    def fetch_failures(output)
+      buffer = ''
+      output.dig('testResults', 'failedTests', 'testResult').each do |test_result|
+        message = ''
+        test_result.dig('errors', 'error').each do |error|
+          message += error['message']
+          buffer += message
+        end
+
+        @failures << {
+          'suite' => test_result['className'],
+          'case' => test_result['methodName'],
+          'message' => message,
+          'execution_time' => test_result['durationInSeconds']
+        }
+      end
+
+      buffer
     end
 
     def skipping_jobs

--- a/lib/github/update_status.rb
+++ b/lib/github/update_status.rb
@@ -66,6 +66,8 @@ module Github
       end
     end
 
+    # The unable2find string must match the phrase defined in the ci-files repository file
+    # github_checks/hook_api.py method __topotest_title_summary
     def failure
       unable2find = "There was some test that failed, but I couldn't find the log."
       fetch_and_update_failures(unable2find) if !@output.empty? and @output[:summary].match?(unable2find)

--- a/spec/lib/bamboo_ci/result_spec.rb
+++ b/spec/lib/bamboo_ci/result_spec.rb
@@ -1,0 +1,37 @@
+#  SPDX-License-Identifier: BSD-2-Clause
+#
+#  stop_plan_spec.rb
+#  Part of NetDEF CI System
+#
+#  Copyright (c) 2023 by
+#  Network Device Education Foundation, Inc. ("NetDEF")
+#
+#  frozen_string_literal: true
+
+describe BambooCi::Result do
+  context 'when call fetch' do
+    let(:service) { described_class.fetch(job_key) }
+    let(:job_key) { 1 }
+    let(:url) { "https://127.0.0.1/rest/api/latest/result/#{job_key}?expand=testResults.failedTests.testResult.errors" }
+
+    before do
+      allow(Netrc).to receive(:read).and_return({ 'ci1.netdef.org' => %w[user password] })
+
+      stub_request(:get, url)
+        .with(
+          headers: {
+            'Accept' => %w[*/* application/json],
+            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Authorization' => 'Basic dXNlcjpwYXNzd29yZA==',
+            'Host' => '127.0.0.1',
+            'User-Agent' => 'Ruby'
+          }
+        )
+        .to_return(status: 200, body: {}.to_json, headers: {})
+    end
+
+    it 'must returns success' do
+      expect(service).to eq({})
+    end
+  end
+end


### PR DESCRIPTION
If the script are unable to read the XML and extracts the errors.
During the update process it will identify if there is a specific string and will replace it with the error that is in bamboo.