### PR TITLE
WatchDog - Change to use build status

### DIFF
--- a/workers/base.rb
+++ b/workers/base.rb
@@ -21,6 +21,10 @@ class Base
     @result = get_status(check_suite.bamboo_ci_ref)
   end
 
+  def fetch_build_status(check_suite)
+    get_request(URI("https://127.0.0.1/rest/api/latest/result/status/#{check_suite.bamboo_ci_ref}"))
+  end
+
   def check_stages
     @result.dig('stages', 'stage').each do |stage|
       stage.dig('results', 'result').each do |result|

--- a/workers/watch_dog.rb
+++ b/workers/watch_dog.rb
@@ -14,22 +14,35 @@ require_relative 'base'
 class WatchDog < Base
   def perform
     @logger = Logger.new('watch_dog.log', 0, 1_024_000)
-    check_suites.each do |check_suite|
+    @logger.info '>>> Running watchdog'
+
+    suites = check_suites
+
+    @logger.info ">>> Suites that need to be updated: #{suites.size}"
+
+    check(suites)
+
+    @logger.info '>>> Stopping watchdog'
+  end
+
+  private
+
+  def check(suites)
+    suites.each do |check_suite|
       @logger.info ">>> CheckSuite: #{check_suite.inspect}"
 
       fetch_ci_execution(check_suite)
+      build_status = fetch_build_status(check_suite)
 
-      @logger.info ">>> Status: #{@result['state']}"
+      @logger.info "Build status: #{build_status.inspect}"
 
-      next if @result['status-code'] == 404
-      next if @result['state'] == 'Unknown'
+      next if !build_status&.key?('message') or !build_status['finished']
+      next if build_status&.dig('progress', 'percentageCompleted').to_f < 2.0
 
       check_stages(check_suite)
       clear_deleted_jobs(check_suite)
     end
   end
-
-  private
 
   def check_suites
     CheckSuite.where(id: check_suites_fetch_map)


### PR DESCRIPTION
In this PR we will change the way we check if the execution hung or froze. Instead, using the execution result we will validate the build status.
With this we know whether the execution was suspended or not.