### PR TITLE
Skipping removed Bamboo Test/Build

### DIFF
--- a/lib/bamboo_ci/api.rb
+++ b/lib/bamboo_ci/api.rb
@@ -12,6 +12,7 @@ require 'net/http'
 require 'net/https'
 require 'netrc'
 require 'json'
+require 'multipart/post'
 
 require_relative '../helpers/request'
 

--- a/lib/github/build/unavailable_jobs.rb
+++ b/lib/github/build/unavailable_jobs.rb
@@ -1,0 +1,51 @@
+#  SPDX-License-Identifier: BSD-2-Clause
+#
+#  unavailable_jobs.rb
+#  Part of NetDEF CI System
+#
+#  Copyright (c) 2023 by
+#  Network Device Education Foundation, Inc. ("NetDEF")
+#
+#  frozen_string_literal: true
+
+require_relative '../check'
+require_relative '../../bamboo_ci/running_plan'
+
+module Github
+  module Build
+    class UnavailableJobs
+      def initialize(check_suite)
+        return if check_suite.nil?
+
+        @check_suite = check_suite
+        @github = Github::Check.new(@check_suite)
+        @logger = Logger.new('github_unavailable_jobs.log', 1, 1_024_000)
+      end
+
+      def update(new_check_suite: nil)
+        return if @check_suite.nil?
+
+        @logger.warn '>>> Check Unavailable Jobs'
+
+        running_jobs =
+          BambooCi::RunningPlan.fetch(@check_suite.bamboo_ci_ref).map { |entry| entry[:job_ref] }
+
+        @check_suite.ci_jobs.where.not(job_ref: running_jobs).each do |unavailable_job|
+          @logger.warn ">>> Unavailable Job: #{unavailable_job.inspect}"
+          unavailable_job.skipped(@github, output(unavailable_job))
+          unavailable_job.update(check_suite: new_check_suite) unless new_check_suite.nil?
+        end
+      end
+
+      private
+
+      def output(unavailable_job)
+        {
+          title: unavailable_job.name,
+          summary: 'This check has been removed from the CI execution plan and in your ' \
+                   'next commit or rebase it will not be executed and will not appear in the Check Run list.'
+        }
+      end
+    end
+  end
+end

--- a/lib/github/check.rb
+++ b/lib/github/check.rb
@@ -90,11 +90,7 @@ module Github
     end
 
     def installation_id
-      list = @authenticate_app.find_app_installations
-
-      return 0 if list.first.is_a? Array and list.first&.last&.match? 'Missing'
-
-      list.first['id']
+      @authenticate_app.find_app_installations.first['id'].to_i
     end
 
     def signature
@@ -127,6 +123,8 @@ module Github
     # PS: Conclusion and status are the same name from GitHub Check doc.
     # https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#update-a-check-run
     def completed(check_ref, status, conclusion, output)
+      return if check_ref.nil?
+
       opts = {
         status: status,
         conclusion: conclusion,
@@ -140,8 +138,6 @@ module Github
         check_ref,
         opts
       )
-    rescue Octokit::NotFound
-      @logger.error "check_ref ##{check_ref} not found at GitHub"
     end
 
     def authenticate_app

--- a/lib/github/re_run/base.rb
+++ b/lib/github/re_run/base.rb
@@ -14,6 +14,7 @@ require_relative '../../bamboo_ci/stop_plan'
 require_relative '../parsers/pull_request_commit'
 
 require_relative '../check'
+require_relative '../build/unavailable_jobs'
 
 module Github
   module ReRun
@@ -47,7 +48,7 @@ module Github
         logger(Logger::INFO, fetch_run_ci_by_pr.inspect)
 
         fetch_run_ci_by_pr.each do |check_suite|
-          check_suite.ci_jobs.each do |ci_job|
+          check_suite.ci_jobs.not_skipped.each do |ci_job|
             BambooCi::StopPlan.stop(ci_job.job_ref)
 
             logger(Logger::WARN, "Cancelling Job #{ci_job.inspect}")
@@ -112,6 +113,10 @@ module Github
         check_suite.update(bamboo_ci_ref: bamboo_plan.bamboo_reference, re_run: true)
 
         create_ci_jobs(bamboo_plan, check_suite)
+
+        CheckSuite.where(commit_sha_ref: check_suite.commit_sha_ref).each do |cs|
+          Github::Build::UnavailableJobs.new(cs).update(new_check_suite: check_suite)
+        end
 
         SlackBot.instance.execution_started_notification(check_suite)
       end

--- a/lib/github/retry.rb
+++ b/lib/github/retry.rb
@@ -15,6 +15,7 @@ require_relative '../bamboo_ci/retry'
 require_relative '../bamboo_ci/stop_plan'
 
 require_relative 'check'
+require_relative 'build/unavailable_jobs'
 
 module Github
   class Retry
@@ -49,6 +50,7 @@ module Github
       create_ci_jobs(check_suite)
 
       BambooCi::Retry.restart(check_suite.bamboo_ci_ref)
+      Github::Build::UnavailableJobs.new(check_suite).update
 
       SlackBot.instance.execution_started_notification(check_suite)
 
@@ -64,7 +66,7 @@ module Github
         ci_job.enqueue(github_check)
         ci_job.update(retry: ci_job.retry + 1)
 
-        logger(Logger::WARN, "Stopping Job: #{ci_job.job_ref}")
+        logger(Logger::WARN, "Stopping Job: #{ci_job.name} - #{ci_job.job_ref}")
         BambooCi::StopPlan.stop(ci_job.job_ref)
       end
     end

--- a/lib/github/update_status.rb
+++ b/lib/github/update_status.rb
@@ -83,11 +83,6 @@ module Github
       SlackBot.instance.execution_finished_notification(@check_suite)
     end
 
-    def fetch_last_check_suite
-      pull_request = @check_suite.pull_request
-      pull_request.check_suites.all.order(:created_at).last
-    end
-
     def current_execution?
       pull_request = @check_suite.pull_request
       last_check_suite = pull_request.check_suites.reload.all.order(:created_at).last

--- a/lib/github/update_status.rb
+++ b/lib/github/update_status.rb
@@ -140,7 +140,8 @@ module Github
       return unless @job.name.downcase.match?(/(code|build)/) and @status == 'failure'
 
       @job.check_suite.ci_jobs.where(status: :queued).each do |job|
-        job.skipped(@github_check)
+        @logger.info ">>> Skipping job: #{job.inspect}"
+        job.cancelled(@github_check)
       end
     end
 

--- a/lib/helpers/request.rb
+++ b/lib/helpers/request.rb
@@ -12,6 +12,7 @@ require 'net/http'
 require 'net/https'
 require 'netrc'
 require 'json'
+require 'multipart/post'
 
 module GitHubApp
   module Request

--- a/lib/models/ci_job.rb
+++ b/lib/models/ci_job.rb
@@ -20,6 +20,7 @@ class CiJob < ActiveRecord::Base
   has_many :topotest_failures, dependent: :delete_all
 
   scope :sha256, ->(sha) { joins(:check_suite).where(check_suite: { commit_sha_ref: sha }) }
+  scope :not_skipped, -> { where.not(status: 'skipped') }
 
   def checkout_code?
     name.downcase.match? 'checkout'

--- a/spec/lib/github/build/unavailable_jobs_spec.rb
+++ b/spec/lib/github/build/unavailable_jobs_spec.rb
@@ -1,0 +1,72 @@
+#  SPDX-License-Identifier: BSD-2-Clause
+#
+#  unavailable_jobs_spec.rb
+#  Part of NetDEF CI System
+#
+#  Copyright (c) 2023 by
+#  Network Device Education Foundation, Inc. ("NetDEF")
+#
+#  frozen_string_literal: true
+
+describe Github::Build::UnavailableJobs do
+  let(:unavailable_jobs) { described_class.new(check_suite) }
+  let(:check_suite) { create(:check_suite) }
+  let(:jobs) { create_list(:ci_job, 2, check_suite: check_suite) }
+  let(:fake_client) { Octokit::Client.new }
+
+  before do
+    allow(Octokit::Client).to receive(:new).and_return(fake_client)
+    allow(fake_client).to receive(:find_app_installations).and_return([{ 'id' => 1 }])
+    allow(fake_client).to receive(:create_app_installation_access_token).and_return({ 'token' => 1 })
+    allow(fake_client).to receive(:update_check_run)
+    allow(File).to receive(:read).and_return('')
+    allow(OpenSSL::PKey::RSA).to receive(:new).and_return(OpenSSL::PKey::RSA.new(2048))
+  end
+
+  context 'when has a new suite' do
+    let(:unavailable_job) { jobs.last }
+    let(:available_job) { jobs.first }
+    let(:new_check_suite) { create(:check_suite) }
+
+    before do
+      allow(BambooCi::RunningPlan).to receive(:fetch).and_return([{ job_ref: unavailable_job.job_ref }])
+    end
+
+    it 'must change check suite' do
+      unavailable_jobs.update(new_check_suite: new_check_suite)
+      expect(new_check_suite.reload.ci_jobs.size).to eq(1)
+      expect(check_suite.reload.ci_jobs.size).to eq(1)
+    end
+  end
+
+  context 'when has not a new suite' do
+    let(:unavailable_job) { jobs.last }
+    let(:available_job) { jobs.first }
+    let(:new_check_suite) { create(:check_suite) }
+
+    before do
+      allow(BambooCi::RunningPlan).to receive(:fetch).and_return([{ job_ref: unavailable_job.job_ref }])
+    end
+
+    it 'must change check suite' do
+      unavailable_jobs.update
+      expect(new_check_suite.reload.ci_jobs.size).to eq(0)
+      expect(check_suite.reload.ci_jobs.size).to eq(2)
+    end
+  end
+
+  context 'when check suite is null' do
+    let(:check_suite) { nil }
+    let(:unavailable_job) { jobs.last }
+    let(:available_job) { jobs.first }
+    let(:new_check_suite) { create(:check_suite) }
+
+    before do
+      allow(BambooCi::RunningPlan).to receive(:fetch).and_return([{ job_ref: unavailable_job.job_ref }])
+    end
+
+    it 'must return nil' do
+      expect(unavailable_jobs.update).to be_nil
+    end
+  end
+end

--- a/spec/lib/github/check_spec.rb
+++ b/spec/lib/github/check_spec.rb
@@ -187,6 +187,28 @@ describe Github::Check do
     end
   end
 
+  context 'when call success but check_ref is null' do
+    let(:id) { nil }
+    let(:status) { 'completed' }
+    let(:conclusion) { 'success' }
+
+    before do
+      allow(fake_client).to receive(:update_check_run)
+        .with(check_suite.pull_request.repository,
+              id,
+              {
+                status: status,
+                conclusion: conclusion,
+                accept: 'application/vnd.github+json'
+              })
+        .and_return(true)
+    end
+
+    it 'must returns success' do
+      expect(check.success(id)).to be_nil
+    end
+  end
+
   context 'when call failure' do
     let(:id) { 1 }
     let(:status) { 'completed' }
@@ -233,6 +255,48 @@ describe Github::Check do
     end
   end
 
+  context 'when call get_check_run' do
+    let(:id) { 1 }
+
+    before do
+      allow(fake_client).to receive(:check_run).and_return({})
+    end
+
+    it 'must returns success' do
+      expect(check.get_check_run(id)).to eq({})
+    end
+  end
+
+  context 'when call fetch_username' do
+    let(:id) { 1 }
+
+    before do
+      allow(fake_client).to receive(:user).and_return({})
+    end
+
+    it 'must returns success' do
+      expect(check.fetch_username(id)).to eq({})
+    end
+  end
+
+  context 'when call fetch_username and raise' do
+    let(:id) { 1 }
+
+    before do
+      allow(fake_client).to receive(:user).and_raise
+    end
+
+    it 'must returns success' do
+      expect(check.fetch_username(id)).to be_falsey
+    end
+  end
+
+  context 'when call signature' do
+    it 'must returns success' do
+      expect(check.signature).to eq(GitHubApp::Configuration.instance.config.dig('auth_signature', 'password'))
+    end
+  end
+
   describe '#installation_id' do
     context 'when find_app_installations returns error' do
       before do
@@ -261,6 +325,16 @@ describe Github::Check do
 
       it 'must returns raise' do
         expect { check.installation_id }.to raise_error(StandardError)
+      end
+    end
+
+    context 'when authenticate receive zero' do
+      before do
+        allow(fake_client).to receive(:find_app_installations).and_return([{ 'id' => 0 }])
+      end
+
+      it 'must returns raise' do
+        expect { check.installation_id }.to raise_error(StandardError, 'Github Authentication Failed')
       end
     end
   end

--- a/spec/lib/github/re_run/command_spec.rb
+++ b/spec/lib/github/re_run/command_spec.rb
@@ -62,6 +62,7 @@ describe Github::ReRun::Command do
         allow(fake_github_check).to receive(:in_progress)
         allow(fake_github_check).to receive(:queued)
         allow(fake_github_check).to receive(:comment_reaction_thumb_up)
+        allow(fake_github_check).to receive(:skipped)
 
         allow(BambooCi::PlanRun).to receive(:new).and_return(fake_plan_run)
         allow(fake_plan_run).to receive(:start_plan).and_return(200)

--- a/spec/lib/github/re_run/comment_spec.rb
+++ b/spec/lib/github/re_run/comment_spec.rb
@@ -13,10 +13,14 @@ describe Github::ReRun::Comment do
   let(:fake_client) { Octokit::Client.new }
   let(:fake_github_check) { Github::Check.new(nil) }
   let(:fake_plan_run) { BambooCi::PlanRun.new(nil) }
+  let(:fake_unavailable) { Github::Build::UnavailableJobs.new(nil) }
 
   before do
     allow(File).to receive(:read).and_return('')
     allow(OpenSSL::PKey::RSA).to receive(:new).and_return(OpenSSL::PKey::RSA.new(2048))
+
+    allow(Github::Build::UnavailableJobs).to receive(:new).and_return(fake_unavailable)
+    allow(fake_unavailable).to receive(:update).and_return([])
   end
 
   describe 'Invalid payload' do

--- a/spec/lib/github/retry_spec.rb
+++ b/spec/lib/github/retry_spec.rb
@@ -10,10 +10,12 @@
 
 describe Github::Retry do
   let(:github_retry) { described_class.new(payload) }
+  let(:fake_unavailable) { Github::Build::UnavailableJobs.new(nil) }
 
   before do
     allow(File).to receive(:read).and_return('')
     allow(OpenSSL::PKey::RSA).to receive(:new).and_return(OpenSSL::PKey::RSA.new(2048))
+    allow(Github::Build::UnavailableJobs).to receive(:new).and_return(fake_unavailable)
   end
 
   context 'when receives an empty payload' do
@@ -67,6 +69,8 @@ describe Github::Retry do
 
         allow(BambooCi::StopPlan).to receive(:stop)
         allow(BambooCi::Retry).to receive(:restart)
+
+        allow(BambooCi::RunningPlan).to receive(:fetch).and_return([])
 
         ci_job_checkout_code
       end

--- a/spec/lib/github/update_status_spec.rb
+++ b/spec/lib/github/update_status_spec.rb
@@ -10,6 +10,7 @@
 
 describe Github::UpdateStatus do
   let(:update_status) { described_class.new(payload) }
+  let(:fake_unavailable) { Github::Build::UnavailableJobs.new(nil) }
 
   describe 'Validates different Ci Job status' do
     let(:payload) do
@@ -36,6 +37,9 @@ describe Github::UpdateStatus do
       allow(fake_github_check).to receive(:in_progress).and_return(ci_job.check_suite)
       allow(fake_github_check).to receive(:skipped).and_return(ci_job.check_suite)
       allow(fake_github_check).to receive(:success).and_return(ci_job.check_suite)
+      allow(fake_github_check).to receive(:cancelled).and_return(ci_job.check_suite)
+
+      allow(Github::Build::UnavailableJobs).to receive(:new).and_return(fake_unavailable)
     end
 
     context 'when Ci Job Checkout Code update from queued -> failure' do
@@ -78,7 +82,7 @@ describe Github::UpdateStatus do
 
       it 'must returns success' do
         expect(update_status.update).to eq([200, 'Success'])
-        ci_jobs.each { |job| expect(job.reload.status).to eq('skipped') }
+        ci_jobs.each { |job| expect(job.reload.status).to eq('cancelled') }
       end
     end
 


### PR DESCRIPTION
Implemented a class for when a test/build is removed from CI and a rerun is performed, this test will be marked as skipped and allow the branch to be merged.