### PR TITLE
Watchdog - Check if missing stage

### DIFF
--- a/lib/github/build/summary.rb
+++ b/lib/github/build/summary.rb
@@ -10,6 +10,7 @@
 
 require_relative '../../github/check'
 require_relative '../../bamboo_ci/download'
+require_relative '../../bamboo_ci/running_plan'
 
 module Github
   module Build
@@ -223,9 +224,20 @@ module Github
       def fetch_parent_stage
         jobs = BambooCi::RunningPlan.fetch(@check_suite.bamboo_ci_ref)
         info = jobs.find { |job| job[:name] == @job.name }
-        stage = Stage.find_by(check_suite: @check_suite, name: info[:stage])
+
+        stage = first_or_create_stage(info)
+
+        logger(Logger::INFO, "fetch_parent_stage - stage: #{stage.inspect} info[:stage]: #{info[:stage]}")
 
         @job.update(stage: stage)
+
+        stage
+      end
+
+      def first_or_create_stage(info)
+        config = StageConfiguration.find_by(bamboo_stage_name: info[:stage])
+        stage = Stage.find_by(check_suite: @check_suite, name: info[:stage])
+        stage = Stage.create(check_suite: @check_suite, name: info[:stage], configuration: config) if stage.nil?
 
         stage
       end

--- a/lib/models/ci_job.rb
+++ b/lib/models/ci_job.rb
@@ -28,18 +28,6 @@ class CiJob < ActiveRecord::Base
   scope :not_skipped, -> { where.not(status: 'skipped') }
   scope :failure, -> { where(status: %i[failure cancelled skipped]) }
 
-  def checkout_code?
-    name.downcase.match? 'checkout'
-  end
-
-  def build?
-    name.downcase.match? 'build'
-  end
-
-  def test?
-    !build? and !checkout_code?
-  end
-
   def finished?
     !%w[queued in_progress].include?(status)
   end

--- a/lib/models/ci_job.rb
+++ b/lib/models/ci_job.rb
@@ -40,6 +40,10 @@ class CiJob < ActiveRecord::Base
     !build? and !checkout_code?
   end
 
+  def finished?
+    !%w[queued in_progress].include?(status)
+  end
+
   def create_check_run
     update(status: :queued)
   end

--- a/workers/base.rb
+++ b/workers/base.rb
@@ -13,6 +13,7 @@ require_relative '../database_loader'
 require_relative '../lib/bamboo_ci/api'
 require_relative '../lib/github/check'
 require_relative '../lib/helpers/configuration'
+require_relative '../lib/github_ci_app'
 
 class Base
   include BambooCi::Api

--- a/workers/watch_dog.rb
+++ b/workers/watch_dog.rb
@@ -47,6 +47,7 @@ class WatchDog < Base
     end
   end
 
+  # Checks if CI still running
   def in_progress?(build_status)
     return false if ci_stopped?(build_status)
     return false if ci_hanged?(build_status)

--- a/workers/watch_dog.rb
+++ b/workers/watch_dog.rb
@@ -47,13 +47,6 @@ class WatchDog < Base
     end
   end
 
-  def finish_stages(check_suite)
-    check_suite.ci_jobs.stages.each do |stage|
-      summary = Github::Build::Summary.new(stage)
-      summary.missing_stage(stage)
-    end
-  end
-
   def in_progress?(build_status)
     return false if ci_stopped?(build_status)
     return false if ci_hanged?(build_status)
@@ -62,7 +55,7 @@ class WatchDog < Base
   end
 
   def ci_stopped?(build_status)
-    build_status.key?('message') and !build_status.key? 'finished'
+    build_status.key?('message') and !build_status.key?('finished')
   end
 
   def ci_hanged?(build_status)


### PR DESCRIPTION
When the watchdog does not find the stage for a CiJob, we will create an entry and update the object.