### PR TITLE
Summary using invalid status

### DIFF
--- a/lib/github/build/summary.rb
+++ b/lib/github/build/summary.rb
@@ -104,7 +104,7 @@ module Github
             "The previous stage failed and the remaining tests will be canceled.\nDetails at [#{url}](#{url})."
         }
 
-        logger(Logger::INFO, "cancelling_next_stage - pending_stage: #{pending_stage}\n#{output}")
+        logger(Logger::INFO, "cancelling_next_stage - pending_stage: #{pending_stage.inspect}\n#{output}")
 
         pending_stage.cancelled(@github, output: output)
         pending_stage.jobs.each { |job| job.cancelled(@github) }
@@ -112,7 +112,9 @@ module Github
 
       def finished_summary(stage)
         logger(Logger::INFO, "Finished stage: #{stage.inspect}, CiJob status: #{@job.status}")
-        return if @job.in_progress? or stage.jobs.where(status: %w[queue in_progress]).any?
+        logger(Logger::INFO, "Finished stage: #{stage.inspect}, jobs: #{stage.reload.jobs.inspect}")
+
+        return if @job.in_progress? or stage.running?
 
         finished_stage_summary(stage)
       end

--- a/lib/models/check_suite.rb
+++ b/lib/models/check_suite.rb
@@ -19,7 +19,15 @@ class CheckSuite < ActiveRecord::Base
   has_many :stages, dependent: :delete_all
 
   def finished?
-    stages.where(status: %i[queued in_progress]).empty?
+    !running?
+  end
+
+  def running?
+    stages.where(status: %i[queued in_progress]).any?
+  end
+
+  def running_jobs
+    ci_jobs.where(status: %i[queued in_progress])
   end
 
   def in_progress?

--- a/lib/models/stage.rb
+++ b/lib/models/stage.rb
@@ -15,6 +15,10 @@ class Stage < ActiveRecord::Base
   belongs_to :configuration, class_name: 'StageConfiguration', foreign_key: 'stage_configuration_id'
   belongs_to :check_suite
 
+  def running?
+    jobs.where(status: %i[queued in_progress]).any?
+  end
+
   def previous_stage
     position = configuration&.position.to_i
     check_suite.stages.joins(:configuration).find_by(configuration: { position: position - 1 })

--- a/lib/slack/running.rb
+++ b/lib/slack/running.rb
@@ -47,7 +47,7 @@ module Slack
     end
 
     def running_or_queued(check_suite)
-      total = check_suite.ci_jobs.where(status: %i[queued in_progress]).size.to_s
+      total = check_suite.running_jobs.size.to_s
 
       total = "#{' ' * 10}#{total}"
 


### PR DESCRIPTION
During validation if the stage had finished, a scenario could occur in which only one test had started and finished while the others were queued.
Making the system mistakenly understand that it had finished.
