### PR TITLE
Github - Check Run ID

### DIFF
--- a/lib/github/check.rb
+++ b/lib/github/check.rb
@@ -98,6 +98,10 @@ module Github
         .map do |check_run|
         check_run[:id]
       end
+    rescue Octokit::UnprocessableEntity => e
+      @logger.error "fetch_check_runs: #{e.class} #{e.message}"
+
+      []
     end
 
     def installation_id

--- a/lib/github/update_status.rb
+++ b/lib/github/update_status.rb
@@ -47,6 +47,10 @@ module Github
       update_status
 
       [200, 'Success']
+    rescue StandardError => e
+      logger(Logger::ERROR, "#{e.class} #{e.message}")
+
+      [500, 'Internal Server Error']
     end
 
     private

--- a/lib/github/update_status.rb
+++ b/lib/github/update_status.rb
@@ -45,12 +45,6 @@ module Github
       @github_check = Github::Check.new(@job.check_suite)
 
       update_status
-
-      [200, 'Success']
-    rescue StandardError => e
-      logger(Logger::ERROR, "#{e.class} #{e.message}")
-
-      [500, 'Internal Server Error']
     end
 
     private
@@ -87,6 +81,12 @@ module Github
       summary.build_summary
 
       finished_execution?
+
+      [200, 'Success']
+    rescue StandardError => e
+      logger(Logger::ERROR, "#{e.class} #{e.message}")
+
+      [500, 'Internal Server Error']
     end
 
     def finished_execution?


### PR DESCRIPTION
For some unknown reason, it seems that GitHub's check_run_id is losing its validity and cannot update the run interface.

With this, the Bamboo agent starts receiving a 500 when it validates check_run_id, in the previous version it might have received an HTTP CODE 200 and the interface did not update.

In this version, as it validated the existence of the check_run_id with GitHub, it was receiving an error "Octokit::UnprocessableEntity" - "422 - No commit found for SHA" and it ended up having to update the check_run to obtain a new ID.