### PR TITLE
Using Github::PlanExecution::Finished to validate the end of tests

### DIFF
--- a/lib/github/build/summary.rb
+++ b/lib/github/build/summary.rb
@@ -27,7 +27,7 @@ module Github
           @loggers << GithubLogger.instance.create(filename, logger_level)
         end
 
-        @loggers << GithubLogger.instance.create("pr#{@check_suite.pull_request.github_pr_id}.log", logger_level)
+        @pr_log = GithubLogger.instance.create("pr#{@check_suite.pull_request.github_pr_id}.log", logger_level)
       end
 
       def build_summary
@@ -36,6 +36,8 @@ module Github
         check_and_update_github_ref(current_stage)
 
         logger(Logger::INFO, "build_summary: #{current_stage.inspect}")
+        msg = "Github::Build::Summary - #{@job.inspect}, #{current_stage.inspect}, bamboo info: #{bamboo_info}"
+        @pr_log.info(msg)
 
         # Update current stage
         update_summary(current_stage)
@@ -51,6 +53,11 @@ module Github
       end
 
       private
+
+      def bamboo_info
+        finish = Github::PlanExecution::Finished.new({ 'bamboo_ref' => @check_suite.bamboo_ci_ref })
+        finish.fetch_build_status
+      end
 
       def check_and_update_github_ref(current_stage)
         current_refs = @github.fetch_check_runs

--- a/lib/github/plan_execution/finished.rb
+++ b/lib/github/plan_execution/finished.rb
@@ -40,16 +40,8 @@ module Github
         [200, 'Finished']
       end
 
-      private
-
-      # This method will move all tests that no longer exist in BambooCI to the skipped state,
-      # because there are no executions for them.
-      def clear_deleted_jobs
-        github_check = Github::Check.new(@check_suite)
-
-        @check_suite.ci_jobs.where(status: %w[queued in_progress]).each do |ci_job|
-          ci_job.skipped(github_check)
-        end
+      def fetch_build_status
+        get_request(URI("https://127.0.0.1/rest/api/latest/result/status/#{@check_suite.bamboo_ci_ref}"))
       end
 
       # Checks if CI still running
@@ -61,6 +53,18 @@ module Github
         return false if build_status['currentStage'].casecmp('final').zero?
 
         true
+      end
+
+      private
+
+      # This method will move all tests that no longer exist in BambooCI to the skipped state,
+      # because there are no executions for them.
+      def clear_deleted_jobs
+        github_check = Github::Check.new(@check_suite)
+
+        @check_suite.ci_jobs.where(status: %w[queued in_progress]).each do |ci_job|
+          ci_job.skipped(github_check)
+        end
       end
 
       def ci_stopped?(build_status)
@@ -150,10 +154,6 @@ module Github
 
       def fetch_ci_execution
         @result = get_status(@check_suite.bamboo_ci_ref)
-      end
-
-      def fetch_build_status
-        get_request(URI("https://127.0.0.1/rest/api/latest/result/status/#{@check_suite.bamboo_ci_ref}"))
       end
     end
   end


### PR DESCRIPTION
It was adding Github::PlanExecution::Finished to validate whether the execution has finished. 
This can prevent the CI from not updating.