### PR TITLE
CI Retry

### DIFF
--- a/lib/github/build/retry.rb
+++ b/lib/github/build/retry.rb
@@ -45,7 +45,7 @@ module Github
 
       def enqueued_failure_tests
         @check_suite.ci_jobs.where.not(status: :success).each do |ci_job|
-          next unless ci_job.stage.configuration.can_retry?
+          next if must_skip_retry?(ci_job)
 
           logger(Logger::WARN, "Enqueue CiJob: #{ci_job.inspect}")
           ci_job.enqueue(@github)
@@ -56,6 +56,10 @@ module Github
       end
 
       private
+
+      def must_skip_retry?(ci_job)
+        ci_job.stage.nil? || !ci_job.stage.configuration.can_retry?
+      end
 
       def logger(severity, message)
         @loggers.each do |logger_object|


### PR DESCRIPTION
Old PRs that listed all the tests that are run can cause problems when running ci:retry.

Because, the old tests have no relationship with a Stage and break when searching for the configuration