### PR TITLE
GitHub Warnings

### DIFF
--- a/lib/github/check.rb
+++ b/lib/github/check.rb
@@ -51,11 +51,13 @@ module Github
     end
 
     def comment_reaction_thumb_up(repo, comment_id)
-      @app.create_issue_comment_reaction(repo, comment_id, '+1')
+      @app.create_issue_comment_reaction(repo, comment_id, '+1',
+                                         accept: Octokit::Preview::PREVIEW_TYPES[:reactions])
     end
 
     def comment_reaction_thumb_down(repo, comment_id)
-      @app.create_issue_comment_reaction(repo, comment_id, '-1')
+      @app.create_issue_comment_reaction(repo, comment_id, '-1',
+                                         accept: Octokit::Preview::PREVIEW_TYPES[:reactions])
     end
 
     def create(name)
@@ -63,7 +65,7 @@ module Github
         @check_suite.pull_request.repository,
         name,
         @check_suite.commit_sha_ref,
-        accept: 'application/vnd.github.antiope-preview+json'
+        accept: Octokit::Preview::PREVIEW_TYPES[:checks]
       )
     end
 
@@ -94,7 +96,7 @@ module Github
     def get_check_run(check_ref)
       @app.check_run(@check_suite.pull_request.repository,
                      check_ref,
-                     accept: 'application/vnd.github.antiope-preview+json').to_h
+                     accept: Octokit::Preview::PREVIEW_TYPES[:checks]).to_h
     end
 
     def fetch_check_runs
@@ -104,7 +106,7 @@ module Github
         .check_runs_for_ref(
           @check_suite.pull_request.repository,
           @check_suite.pull_request.branch_name,
-          accept: 'application/vnd.github.antiope-preview+json'
+          accept: Octokit::Preview::PREVIEW_TYPES[:checks]
         )
         .to_h[:check_runs]
         .map do |check_run|
@@ -135,7 +137,7 @@ module Github
     def basic_status(check_ref, status, output)
       opts = {
         status: status,
-        accept: 'application/vnd.github.antiope-preview+json'
+        accept: Octokit::Preview::PREVIEW_TYPES[:checks]
       }
 
       opts[:output] = output unless output.empty?

--- a/spec/lib/github/check_spec.rb
+++ b/spec/lib/github/check_spec.rb
@@ -74,7 +74,9 @@ describe Github::Check do
     let(:pr_info) { { comment_id: comment_id } }
 
     before do
-      allow(fake_client).to receive(:create_issue_comment_reaction).with(repo, comment_id, '+1').and_return(pr_info)
+      allow(fake_client).to receive(:create_issue_comment_reaction)
+        .with(repo, comment_id, '+1', accept: Octokit::Preview::PREVIEW_TYPES[:reactions])
+        .and_return(pr_info)
     end
 
     it 'must returns pull request info' do


### PR DESCRIPTION
I added all the "accept" missing in GitHub calls in this PR.
This will make code execution cleaner without warnings.