### PR TITLE
Github::Check fetch a null object

### DIFF
--- a/lib/github/build/summary.rb
+++ b/lib/github/build/summary.rb
@@ -34,7 +34,7 @@ module Github
       def build_summary
         current_stage = @job.stage
         current_stage = fetch_parent_stage if current_stage.nil?
-        check_and_update_github_ref(current_stage)
+        current_stage.refresh_reference(@github)
 
         logger(Logger::INFO, "build_summary: #{current_stage.inspect}")
         msg = "Github::Build::Summary - #{@job.inspect}, #{current_stage.inspect}, bamboo info: #{bamboo_info}"
@@ -58,22 +58,6 @@ module Github
       def bamboo_info
         finish = Github::PlanExecution::Finished.new({ 'bamboo_ref' => @check_suite.bamboo_ci_ref })
         finish.fetch_build_status
-      end
-
-      def check_and_update_github_ref(current_stage)
-        current_refs = @github.fetch_check_runs
-
-        logger(Logger::INFO,
-               'check_and_update_github_ref - current_stage: ' \
-               "#{current_stage.inspect} current_refs: #{current_refs.inspect}")
-
-        return if current_refs.include? current_stage.check_ref.to_i
-
-        logger(Logger::INFO,
-               'check_and_update_github_ref - current_stage: ' \
-               "#{current_stage.inspect} current_refs: #{current_refs.inspect} - Refreshing reference.")
-
-        current_stage.refresh_reference(@github)
       end
 
       def must_update_previous_stage(current_stage)

--- a/lib/github/check.rb
+++ b/lib/github/check.rb
@@ -99,28 +99,6 @@ module Github
                      accept: Octokit::Preview::PREVIEW_TYPES[:checks]).to_h
     end
 
-    def fetch_check_runs
-      return [] if @check_suite.nil?
-
-      check_runs =
-        @app
-        .check_runs_for_ref(
-          @check_suite.pull_request.repository,
-          @check_suite.pull_request.branch_name,
-          accept: Octokit::Preview::PREVIEW_TYPES[:checks]
-        ).to_h[:check_runs]
-
-      return [] if check_runs.nil?
-
-      check_runs.map do |check_run|
-        check_run[:id]
-      end
-    rescue Octokit::UnprocessableEntity => e
-      @logger.error "fetch_check_runs: #{e.class} #{e.message}"
-
-      []
-    end
-
     def installation_id
       @authenticate_app.find_app_installations(accept: 'application/vnd.github.v3+json').first['id'].to_i
     end

--- a/lib/github/check.rb
+++ b/lib/github/check.rb
@@ -102,14 +102,17 @@ module Github
     def fetch_check_runs
       return [] if @check_suite.nil?
 
-      @app
+      check_runs =
+        @app
         .check_runs_for_ref(
           @check_suite.pull_request.repository,
           @check_suite.pull_request.branch_name,
           accept: Octokit::Preview::PREVIEW_TYPES[:checks]
-        )
-        .to_h[:check_runs]
-        .map do |check_run|
+        ).to_h[:check_runs]
+
+      return [] if check_runs.nil?
+
+      check_runs.map do |check_run|
         check_run[:id]
       end
     rescue Octokit::UnprocessableEntity => e

--- a/spec/lib/github/check_spec.rb
+++ b/spec/lib/github/check_spec.rb
@@ -92,8 +92,8 @@ describe Github::Check do
 
     before do
       allow(fake_client).to receive(:create_issue_comment_reaction)
-                              .with(repo, comment_id, '-1', accept: Octokit::Preview::PREVIEW_TYPES[:reactions])
-                              .and_return(pr_info)
+        .with(repo, comment_id, '-1', accept: Octokit::Preview::PREVIEW_TYPES[:reactions])
+        .and_return(pr_info)
     end
 
     it 'must returns pull request info' do

--- a/spec/lib/github/check_spec.rb
+++ b/spec/lib/github/check_spec.rb
@@ -84,6 +84,23 @@ describe Github::Check do
     end
   end
 
+  context 'when call comment_reaction_thumb_down' do
+    let(:pr_id) { 1 }
+    let(:repo) { 'test' }
+    let(:comment_id) { 1 }
+    let(:pr_info) { { comment_id: comment_id } }
+
+    before do
+      allow(fake_client).to receive(:create_issue_comment_reaction)
+                              .with(repo, comment_id, '-1', accept: Octokit::Preview::PREVIEW_TYPES[:reactions])
+                              .and_return(pr_info)
+    end
+
+    it 'must returns pull request info' do
+      expect(check.comment_reaction_thumb_down(repo, comment_id)).to eq(pr_info)
+    end
+  end
+
   context 'when call create' do
     let(:pr_id) { 1 }
     let(:name) { 'test' }


### PR DESCRIPTION
May receive a null object when searching for all check runs referring to Pull Request.