### PR TITLE
RetrieveError and UpdateStatus

### DIFF
--- a/lib/github/topotest_failures/retrieve_error.rb
+++ b/lib/github/topotest_failures/retrieve_error.rb
@@ -1,0 +1,39 @@
+#  SPDX-License-Identifier: BSD-2-Clause
+#
+#  retrieve_error.rb
+#  Part of NetDEF CI System
+#
+#  Copyright (c) 2024 by
+#  Network Device Education Foundation, Inc. ("NetDEF")
+#
+#  frozen_string_literal: true
+
+module Github
+  module TopotestFailures
+    class RetrieveError
+      attr_reader :failures
+
+      def initialize(job)
+        @job = job
+        @failures = []
+      end
+
+      def retrieve
+        fetch_failures(BambooCi::Result.fetch(@job.job_ref))
+
+        @failures
+      end
+
+      def fetch_failures(output)
+        output.dig('testResults', 'failedTests', 'testResult')&.each do |test_result|
+          @failures << {
+            'suite' => test_result['className'],
+            'case' => test_result['methodName'],
+            'message' => message,
+            'execution_time' => test_result['durationInSeconds']
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/github/topotest_failures/retrieve_error.rb
+++ b/lib/github/topotest_failures/retrieve_error.rb
@@ -29,7 +29,7 @@ module Github
           @failures << {
             'suite' => test_result['className'],
             'case' => test_result['methodName'],
-            'message' => message,
+            'message' => test_result.dig('errors', 'error').map { |error| error['message'] }.join("\n"),
             'execution_time' => test_result['durationInSeconds']
           }
         end

--- a/lib/github/update_status.rb
+++ b/lib/github/update_status.rb
@@ -20,21 +20,12 @@ module Github
     def initialize(payload)
       @status = payload['status']
 
-      @output =
-        if payload.dig('output', 'title').nil? and payload.dig('output', 'summary').nil?
-          {}
-        else
-          { title: payload.dig('output', 'title'), summary: payload.dig('output', 'summary') }
-        end
-
       @reference = payload['bamboo_ref'] || 'invalid_reference'
       @job = CiJob.find_by(job_ref: payload['bamboo_ref'])
       @check_suite = @job&.check_suite
       @failures = payload['failures']
 
       logger_initializer
-      logger(Logger::WARN, "UpdateStatus: #{@reference} #{@status} (Output in info log)")
-      logger(Logger::INFO, "UpdateStatus: #{@reference} #{@status} #{@output}")
     end
 
     def update
@@ -68,9 +59,9 @@ module Github
     def update_status
       case @status
       when 'in_progress'
-        @job.in_progress(@github_check, output: @output)
+        @job.in_progress(@github_check)
       when 'success'
-        @job.success(@github_check, output: @output)
+        @job.success(@github_check)
         slack_notify_success
       else
         failure
@@ -128,46 +119,26 @@ module Github
     # The unable2find string must match the phrase defined in the ci-files repository file
     # github_checks/hook_api.py method __topotest_title_summary
     def failure
-      unable2find = "There was some test that failed, but I couldn't find the log."
-      fetch_and_update_failures(unable2find) if !@output.empty? and @output[:summary].match?(unable2find)
+      @job.failure(@github_check)
 
-      @job.failure(@github_check, output: @output)
-      failures_stats if @job.name.downcase.match? 'topotest' and @failures.is_a? Array
+      retrieve_stats
     end
 
-    def fetch_and_update_failures(to_be_replaced)
-      count = 0
-      begin
-        output = BambooCi::Result.fetch(@job.job_ref)
-        return if output.nil? or output.empty?
+    def retrieve_stats
+      return failures_stats if @failures.is_a? Array and !@failures.empty?
 
-        @output[:summary] = @output[:summary].sub(to_be_replaced, fetch_failures(output))[0..65_535]
-      rescue NoMethodError => e
-        logger Logger::ERROR, "#{e.class} #{e.message}"
-        count += 1
-        sleep 5
-        retry if count <= 10
-      end
+      retrieve_errors
     end
 
-    def fetch_failures(output)
-      buffer = ''
-      output.dig('testResults', 'failedTests', 'testResult')&.each do |test_result|
-        message = ''
-        test_result.dig('errors', 'error').each do |error|
-          message += error['message']
-          buffer += message
-        end
+    def retrieve_errors
+      @retrieve_error = Github::TopotestFailures::RetrieveError.new(@job)
+      @retrieve_error.retrieve
 
-        @failures << {
-          'suite' => test_result['className'],
-          'case' => test_result['methodName'],
-          'message' => message,
-          'execution_time' => test_result['durationInSeconds']
-        }
-      end
+      return if @retrieve_error.failures.empty?
 
-      buffer
+      @failures = @retrieve_error.failures
+
+      failures_stats
     end
 
     def slack_notify_success

--- a/lib/github_ci_app.rb
+++ b/lib/github_ci_app.rb
@@ -28,6 +28,7 @@ require_relative 'github/retry/comment'
 require_relative 'github/update_status'
 require_relative 'github/plan_execution/finished'
 require_relative 'github/user_info'
+require_relative 'github/topotest_failures/retrieve_error'
 
 # Helpers libs
 require_relative 'helpers/configuration'

--- a/tasks/retrieve_address_sanitizer_error.rb
+++ b/tasks/retrieve_address_sanitizer_error.rb
@@ -17,7 +17,6 @@
 
 require_relative '../config/setup'
 
-
 CiJob
   .where("ci_jobs.name LIKE '%AddressSanitizer%'")
   .where(status: :failure)
@@ -38,4 +37,3 @@ CiJob
     end
   end
 end
-

--- a/tasks/retrieve_address_sanitizer_error.rb
+++ b/tasks/retrieve_address_sanitizer_error.rb
@@ -1,0 +1,41 @@
+#  SPDX-License-Identifier: BSD-2-Clause
+#
+#  retrieve_address_sanitizer_error.rb
+#
+#  > Overview
+#  The retrieve_address_sanitizer_error.rb script is part of the NetDEF CI System.
+#  It is designed to retrieve and log AddressSanitizer errors from CI jobs that have failed.
+#  The script processes CI jobs, retrieves errors using the Github::TopotestFailures::RetrieveError class,
+#  and logs these errors into the TopotestFailure model.
+#
+#  Part of NetDEF CI System
+#
+#  Copyright (c) 2024 by
+#  Network Device Education Foundation, Inc. ("NetDEF")
+#
+#  frozen_string_literal: true
+
+require_relative '../config/setup'
+
+
+CiJob
+  .where("ci_jobs.name LIKE '%AddressSanitizer%'")
+  .where(status: :failure)
+  .each do |job|
+  next if job.topotest_failures.any?
+
+  CiJob.transaction do
+    failures = Github::TopotestFailures::RetrieveError.new(job).retrieve
+
+    next if failures.empty?
+
+    failures.each do |failure|
+      TopotestFailure.create(ci_job: job,
+                             test_suite: failure['suite'],
+                             test_case: failure['case'],
+                             message: failure['message'],
+                             execution_time: failure['execution_time'])
+    end
+  end
+end
+


### PR DESCRIPTION
Created a class to search for CI errors and leave them in the format expected by TopotestFailure. 
Simplifying the code to use the new class