### PR TITLE
Update Status

### DIFF
--- a/lib/github/update_status.rb
+++ b/lib/github/update_status.rb
@@ -121,24 +121,11 @@ module Github
     def failure
       @job.failure(@github_check)
 
-      retrieve_stats
-    end
-
-    def retrieve_stats
       return failures_stats if @failures.is_a? Array and !@failures.empty?
 
-      retrieve_errors
-    end
-
-    def retrieve_errors
-      @retrieve_error = Github::TopotestFailures::RetrieveError.new(@job)
-      @retrieve_error.retrieve
-
-      return if @retrieve_error.failures.empty?
-
-      @failures = @retrieve_error.failures
-
-      failures_stats
+      CiJobFetchTopotestFailures
+        .delay(run_at: 60.seconds.from_now, queue: 'fetch_topotest_failures')
+        .update(@job.id)
     end
 
     def slack_notify_success

--- a/lib/github_ci_app.rb
+++ b/lib/github_ci_app.rb
@@ -38,7 +38,9 @@ require_relative 'helpers/request'
 require_relative 'helpers/sinatra_payload'
 require_relative 'helpers/telemetry'
 
+# Workers
 require_relative '../workers/ci_job_status'
+require_relative '../workers/ci_job_fetch_topotest_failures'
 
 # Slack libs
 require_relative 'slack/slack'

--- a/workers/ci_job_fetch_topotest_failures.rb
+++ b/workers/ci_job_fetch_topotest_failures.rb
@@ -1,0 +1,36 @@
+#  SPDX-License-Identifier: BSD-2-Clause
+#
+#  ci_job_fetch_topotest_failures.rb
+#  Part of NetDEF CI System
+#
+#  Copyright (c) 2024 by
+#  Network Device Education Foundation, Inc. ("NetDEF")
+#
+#  frozen_string_literal: true
+
+class CiJobFetchTopotestFailures
+  def self.update(ci_job_id)
+    @job = CiJob.find(ci_job_id)
+
+    @retrieve_error = Github::TopotestFailures::RetrieveError.new(@job)
+    @retrieve_error.retrieve
+
+    return if @retrieve_error.failures.empty?
+
+    @failures = @retrieve_error.failures
+
+    failures_stats
+  end
+
+  private
+
+  def failures_stats
+    @failures.each do |failure|
+      TopotestFailure.create(ci_job: @job,
+                             test_suite: failure['suite'],
+                             test_case: failure['case'],
+                             message: failure['message'],
+                             execution_time: failure['execution_time'])
+    end
+  end
+end

--- a/workers/ci_job_fetch_topotest_failures.rb
+++ b/workers/ci_job_fetch_topotest_failures.rb
@@ -19,12 +19,6 @@ class CiJobFetchTopotestFailures
 
     @failures = @retrieve_error.failures
 
-    failures_stats
-  end
-
-  private
-
-  def failures_stats
     @failures.each do |failure|
       TopotestFailure.create(ci_job: @job,
                              test_suite: failure['suite'],


### PR DESCRIPTION
Apparently, address sanitize errors take a long time to be made available in the Bamboo API, so we will use the Delayed Job to retrieve the execution results after 1 minute.